### PR TITLE
feat(agent): implement Project Cleanup Agent for project structure cleanup

### DIFF
--- a/tapps_agents/agents/cleanup/__init__.py
+++ b/tapps_agents/agents/cleanup/__init__.py
@@ -1,0 +1,7 @@
+"""
+Cleanup Agent - Project structure analysis and cleanup
+"""
+
+from .agent import CleanupAgent
+
+__all__ = ["CleanupAgent"]

--- a/tapps_agents/agents/cleanup/agent.py
+++ b/tapps_agents/agents/cleanup/agent.py
@@ -1,0 +1,445 @@
+"""
+Cleanup Agent - Project structure analysis and intelligent cleanup
+
+This agent helps keep projects clean by:
+- Analyzing project structure for cleanup opportunities
+- Detecting duplicate files, outdated docs, and naming inconsistencies
+- Generating cleanup plans with rationale for each action
+- Executing cleanup operations safely with backups and rollback
+"""
+
+from pathlib import Path
+from typing import Any
+
+from ...core.agent_base import BaseAgent
+from ...core.config import ProjectConfig, load_config
+from ...utils.project_cleanup_agent import (
+    AnalysisReport,
+    CleanupAgent as CleanupAgentUtil,
+    CleanupPlan,
+    ExecutionReport,
+    ProjectAnalyzer,
+)
+
+
+class CleanupAgent(BaseAgent):
+    """
+    Cleanup Agent - Project structure analysis and cleanup.
+
+    Permissions: Read, Write, Edit, Glob, Bash
+
+    This agent provides guided project cleanup capabilities:
+    - Analyze project structure (duplicates, outdated files, naming issues)
+    - Generate cleanup plans with user confirmation
+    - Execute cleanup operations safely with backups
+    - Support dry-run mode for previewing changes
+    """
+
+    def __init__(self, config: ProjectConfig | None = None):
+        super().__init__(
+            agent_id="cleanup-agent",
+            agent_name="Cleanup Agent",
+            config=config,
+        )
+        # Use config if provided, otherwise load defaults
+        if config is None:
+            config = load_config()
+        self.config = config
+
+        # Get cleanup agent config
+        cleanup_config = config.agents.cleanup_agent if config and config.agents else None
+        self.dry_run_default = cleanup_config.dry_run_default if cleanup_config else True
+        self.backup_enabled = cleanup_config.backup_enabled if cleanup_config else True
+        self.interactive_mode = cleanup_config.interactive_mode if cleanup_config else True
+
+        # Utility components (lazily initialized)
+        self._util: CleanupAgentUtil | None = None
+        self._analyzer: ProjectAnalyzer | None = None
+
+    def _get_util(self, project_root: Path | None = None) -> CleanupAgentUtil:
+        """Get or create the cleanup utility instance."""
+        root = project_root or self._project_root or Path.cwd()
+        if self._util is None or self._util.project_root != root:
+            self._util = CleanupAgentUtil(root)
+        return self._util
+
+    def _get_analyzer(self, project_root: Path | None = None) -> ProjectAnalyzer:
+        """Get or create the analyzer instance."""
+        root = project_root or self._project_root or Path.cwd()
+        if self._analyzer is None or self._analyzer.project_root != root:
+            self._analyzer = ProjectAnalyzer(root)
+        return self._analyzer
+
+    def get_commands(self) -> list[dict[str, str]]:
+        """Return list of available commands."""
+        commands = super().get_commands()
+        commands.extend(
+            [
+                {
+                    "command": "*analyze",
+                    "description": "Analyze project structure for cleanup opportunities",
+                },
+                {
+                    "command": "*plan",
+                    "description": "Generate cleanup plan from analysis",
+                },
+                {
+                    "command": "*execute",
+                    "description": "Execute cleanup plan (dry-run by default)",
+                },
+                {
+                    "command": "*run",
+                    "description": "Run full cleanup workflow (analyze, plan, execute)",
+                },
+            ]
+        )
+        return commands
+
+    async def run(self, command: str, **kwargs) -> dict[str, Any]:
+        """Execute a command."""
+        if command == "analyze":
+            return await self.analyze_command(**kwargs)
+        elif command == "plan":
+            return await self.plan_command(**kwargs)
+        elif command == "execute":
+            return await self.execute_command(**kwargs)
+        elif command == "run":
+            return await self.run_full_cleanup_command(**kwargs)
+        elif command == "help":
+            return self._help()
+        else:
+            return {"error": f"Unknown command: {command}"}
+
+    async def analyze_command(
+        self,
+        path: str | Path | None = None,
+        pattern: str = "*.md",
+        output: str | Path | None = None,
+    ) -> dict[str, Any]:
+        """
+        Analyze project structure for cleanup opportunities.
+
+        Args:
+            path: Path to analyze (defaults to project docs/)
+            pattern: File pattern to match (default: *.md)
+            output: Optional output file for analysis report
+
+        Returns:
+            Analysis report with duplicates, outdated files, naming issues
+        """
+        project_root = self._project_root or Path.cwd()
+        scan_path = Path(path) if path else project_root / "docs"
+
+        if not scan_path.exists():
+            return {
+                "error": f"Path does not exist: {scan_path}",
+                "type": "analyze",
+                "success": False,
+            }
+
+        try:
+            util = self._get_util(project_root)
+            report = await util.run_analysis(scan_path, pattern)
+
+            result = {
+                "type": "analyze",
+                "success": True,
+                "report": {
+                    "total_files": report.total_files,
+                    "total_size_mb": report.total_size / 1024 / 1024,
+                    "duplicate_groups": len(report.duplicates),
+                    "duplicate_files": report.duplicate_count,
+                    "potential_savings_kb": report.potential_savings / 1024,
+                    "outdated_files": len(report.outdated_files),
+                    "obsolete_files": report.obsolete_file_count,
+                    "naming_issues": len(report.naming_issues),
+                    "timestamp": report.timestamp.isoformat(),
+                    "scan_path": str(report.scan_path),
+                },
+                "summary": report.to_markdown(),
+                "message": f"Analysis complete: {report.total_files} files analyzed",
+            }
+
+            # Save report if output specified
+            if output:
+                output_path = Path(output)
+                output_path.write_text(report.model_dump_json(indent=2))
+                result["output_file"] = str(output_path)
+
+            return result
+
+        except Exception as e:
+            return {
+                "type": "analyze",
+                "success": False,
+                "error": str(e),
+            }
+
+    async def plan_command(
+        self,
+        analysis_file: str | Path | None = None,
+        path: str | Path | None = None,
+        pattern: str = "*.md",
+        output: str | Path | None = None,
+    ) -> dict[str, Any]:
+        """
+        Generate cleanup plan from analysis.
+
+        Args:
+            analysis_file: Path to analysis report JSON (optional)
+            path: Path to analyze if no analysis file (defaults to docs/)
+            pattern: File pattern if running fresh analysis
+            output: Optional output file for cleanup plan
+
+        Returns:
+            Cleanup plan with prioritized actions
+        """
+        project_root = self._project_root or Path.cwd()
+
+        try:
+            # Load analysis or run fresh
+            if analysis_file:
+                analysis_path = Path(analysis_file)
+                if not analysis_path.exists():
+                    return {
+                        "error": f"Analysis file not found: {analysis_path}",
+                        "type": "plan",
+                        "success": False,
+                    }
+                analysis = AnalysisReport.model_validate_json(analysis_path.read_text())
+            else:
+                scan_path = Path(path) if path else project_root / "docs"
+                util = self._get_util(project_root)
+                analysis = await util.run_analysis(scan_path, pattern)
+
+            # Generate plan
+            util = self._get_util(project_root)
+            plan = util.run_planning(analysis)
+
+            result = {
+                "type": "plan",
+                "success": True,
+                "plan": {
+                    "total_actions": len(plan.actions),
+                    "high_priority": plan.high_priority_count,
+                    "medium_priority": plan.medium_priority_count,
+                    "low_priority": plan.low_priority_count,
+                    "estimated_savings_mb": plan.estimated_savings / 1024 / 1024,
+                    "estimated_file_reduction": f"{plan.estimated_file_reduction:.1f}%",
+                    "created_at": plan.created_at.isoformat(),
+                },
+                "actions_preview": [
+                    {
+                        "type": str(a.action_type),
+                        "files": [str(f) for f in a.source_files],
+                        "target": str(a.target_path) if a.target_path else None,
+                        "rationale": a.rationale,
+                        "priority": a.priority,
+                        "safety": str(a.safety_level),
+                        "requires_confirmation": a.requires_confirmation,
+                    }
+                    for a in plan.actions[:10]  # Preview first 10
+                ],
+                "summary": plan.to_markdown(),
+                "message": f"Plan generated: {len(plan.actions)} actions",
+            }
+
+            # Save plan if output specified
+            if output:
+                output_path = Path(output)
+                output_path.write_text(plan.model_dump_json(indent=2))
+                result["output_file"] = str(output_path)
+
+            return result
+
+        except Exception as e:
+            return {
+                "type": "plan",
+                "success": False,
+                "error": str(e),
+            }
+
+    async def execute_command(
+        self,
+        plan_file: str | Path | None = None,
+        path: str | Path | None = None,
+        pattern: str = "*.md",
+        dry_run: bool | None = None,
+        backup: bool | None = None,
+    ) -> dict[str, Any]:
+        """
+        Execute cleanup plan.
+
+        Args:
+            plan_file: Path to cleanup plan JSON (optional)
+            path: Path to analyze if no plan file
+            pattern: File pattern if running fresh
+            dry_run: Preview changes without executing (default: True)
+            backup: Create backup before execution (default: True)
+
+        Returns:
+            Execution report with results
+        """
+        project_root = self._project_root or Path.cwd()
+
+        # Use defaults if not specified
+        if dry_run is None:
+            dry_run = self.dry_run_default
+        if backup is None:
+            backup = self.backup_enabled
+
+        try:
+            # Load plan or generate fresh
+            if plan_file:
+                plan_path = Path(plan_file)
+                if not plan_path.exists():
+                    return {
+                        "error": f"Plan file not found: {plan_path}",
+                        "type": "execute",
+                        "success": False,
+                    }
+                plan = CleanupPlan.model_validate_json(plan_path.read_text())
+            else:
+                # Run analysis and planning first
+                scan_path = Path(path) if path else project_root / "docs"
+                util = self._get_util(project_root)
+                analysis = await util.run_analysis(scan_path, pattern)
+                plan = util.run_planning(analysis)
+
+            # Execute plan
+            util = self._get_util(project_root)
+            report = await util.run_execution(plan, dry_run=dry_run, create_backup=backup)
+
+            result = {
+                "type": "execute",
+                "success": True,
+                "dry_run": report.dry_run,
+                "report": {
+                    "total_operations": len(report.operations),
+                    "successful": report.success_count,
+                    "failed": report.failure_count,
+                    "files_deleted": report.files_deleted,
+                    "files_moved": report.files_moved,
+                    "files_renamed": report.files_renamed,
+                    "files_modified": report.files_modified,
+                    "duration_seconds": report.duration_seconds,
+                    "backup_location": str(report.backup_location) if report.backup_location else None,
+                },
+                "summary": report.to_markdown(),
+                "message": (
+                    f"{'Dry run' if dry_run else 'Execution'} complete: "
+                    f"{report.success_count} successful, {report.failure_count} failed"
+                ),
+            }
+
+            return result
+
+        except Exception as e:
+            return {
+                "type": "execute",
+                "success": False,
+                "error": str(e),
+            }
+
+    async def run_full_cleanup_command(
+        self,
+        path: str | Path | None = None,
+        pattern: str = "*.md",
+        dry_run: bool | None = None,
+        backup: bool | None = None,
+    ) -> dict[str, Any]:
+        """
+        Run full cleanup workflow (analyze, plan, execute).
+
+        Args:
+            path: Path to analyze (defaults to docs/)
+            pattern: File pattern to match
+            dry_run: Preview changes without executing (default: True)
+            backup: Create backup before execution (default: True)
+
+        Returns:
+            Combined report with analysis, plan, and execution results
+        """
+        project_root = self._project_root or Path.cwd()
+        scan_path = Path(path) if path else project_root / "docs"
+
+        # Use defaults if not specified
+        if dry_run is None:
+            dry_run = self.dry_run_default
+        if backup is None:
+            backup = self.backup_enabled
+
+        if not scan_path.exists():
+            return {
+                "error": f"Path does not exist: {scan_path}",
+                "type": "run",
+                "success": False,
+            }
+
+        try:
+            util = self._get_util(project_root)
+            analysis, plan, execution = await util.run_full_cleanup(
+                scan_path,
+                pattern,
+                dry_run=dry_run,
+                create_backup=backup,
+            )
+
+            return {
+                "type": "run",
+                "success": True,
+                "dry_run": execution.dry_run,
+                "analysis": {
+                    "total_files": analysis.total_files,
+                    "duplicates": analysis.duplicate_count,
+                    "outdated": len(analysis.outdated_files),
+                    "naming_issues": len(analysis.naming_issues),
+                },
+                "plan": {
+                    "total_actions": len(plan.actions),
+                    "estimated_savings_mb": plan.estimated_savings / 1024 / 1024,
+                },
+                "execution": {
+                    "successful": execution.success_count,
+                    "failed": execution.failure_count,
+                    "files_modified": execution.files_modified,
+                    "backup_location": str(execution.backup_location) if execution.backup_location else None,
+                },
+                "summary": "\n".join([
+                    "=" * 60,
+                    analysis.to_markdown(),
+                    "=" * 60,
+                    plan.to_markdown(),
+                    "=" * 60,
+                    execution.to_markdown(),
+                ]),
+                "message": (
+                    f"{'Dry run' if dry_run else 'Cleanup'} complete: "
+                    f"{analysis.total_files} files analyzed, "
+                    f"{len(plan.actions)} actions, "
+                    f"{execution.success_count} successful"
+                ),
+            }
+
+        except Exception as e:
+            return {
+                "type": "run",
+                "success": False,
+                "error": str(e),
+            }
+
+    def _help(self) -> dict[str, Any]:
+        """Return help information for Cleanup Agent."""
+        examples = [
+            "  *analyze --path ./docs --pattern '*.md'",
+            "  *plan --analysis-file analysis.json --output cleanup-plan.json",
+            "  *execute --plan-file cleanup-plan.json --dry-run",
+            "  *run --path ./docs --dry-run --backup",
+        ]
+        help_text = "\n".join([self.format_help(), "\nExamples:", *examples])
+        return {"type": "help", "content": help_text}
+
+    async def close(self):
+        """Close agent and clean up resources."""
+        self._util = None
+        self._analyzer = None

--- a/tapps_agents/cli/commands/cleanup_agent.py
+++ b/tapps_agents/cli/commands/cleanup_agent.py
@@ -1,0 +1,92 @@
+"""
+Cleanup Agent command handlers
+"""
+import asyncio
+
+from ...agents.cleanup.agent import CleanupAgent
+from ..base import normalize_command
+from ..feedback import get_feedback
+from ..help.static_help import get_static_help
+from ..utils.agent_lifecycle import safe_close_agent_sync
+from .common import check_result_error
+
+
+def handle_cleanup_agent_command(args: object) -> None:
+    """Handle cleanup-agent commands."""
+    feedback = get_feedback()
+    command = normalize_command(getattr(args, "command", None))
+    output_format = getattr(args, "format", "json")
+    feedback.format_type = output_format
+
+    # Help commands first - no activation needed
+    if command == "help" or command is None:
+        help_text = get_static_help("cleanup-agent")
+        feedback.output_result(help_text)
+        return
+
+    # Cleanup agent runs offline (no network needed for file operations)
+    offline_mode = True
+
+    # Create and activate agent
+    cleanup = CleanupAgent()
+    try:
+        asyncio.run(cleanup.activate(offline_mode=offline_mode))
+
+        if command == "analyze":
+            result = asyncio.run(
+                cleanup.run(
+                    "analyze",
+                    path=getattr(args, "path", None),
+                    pattern=getattr(args, "pattern", "*.md"),
+                    output=getattr(args, "output", None),
+                )
+            )
+        elif command == "plan":
+            result = asyncio.run(
+                cleanup.run(
+                    "plan",
+                    analysis_file=getattr(args, "analysis_file", None),
+                    path=getattr(args, "path", None),
+                    pattern=getattr(args, "pattern", "*.md"),
+                    output=getattr(args, "output", None),
+                )
+            )
+        elif command == "execute":
+            # Handle dry-run flag (--no-dry-run disables dry-run)
+            dry_run = not getattr(args, "no_dry_run", False)
+            backup = not getattr(args, "no_backup", False)
+
+            result = asyncio.run(
+                cleanup.run(
+                    "execute",
+                    plan_file=getattr(args, "plan_file", None),
+                    path=getattr(args, "path", None),
+                    pattern=getattr(args, "pattern", "*.md"),
+                    dry_run=dry_run,
+                    backup=backup,
+                )
+            )
+        elif command == "run":
+            # Handle dry-run flag (--no-dry-run disables dry-run)
+            dry_run = not getattr(args, "no_dry_run", False)
+            backup = not getattr(args, "no_backup", False)
+
+            result = asyncio.run(
+                cleanup.run(
+                    "run",
+                    path=getattr(args, "path", None),
+                    pattern=getattr(args, "pattern", "*.md"),
+                    dry_run=dry_run,
+                    backup=backup,
+                )
+            )
+        else:
+            # Invalid command - show help
+            help_text = get_static_help("cleanup-agent")
+            feedback.output_result(help_text)
+            return
+
+        check_result_error(result)
+        feedback.output_result(result, message="Cleanup operation completed successfully")
+    finally:
+        safe_close_agent_sync(cleanup)

--- a/tapps_agents/cli/main.py
+++ b/tapps_agents/cli/main.py
@@ -36,6 +36,7 @@ except (ImportError, AttributeError):
 from .commands import (
     analyst,
     architect,
+    cleanup_agent,
     debugger,
     designer,
     documenter,
@@ -58,6 +59,9 @@ from .feedback import FeedbackManager, ProgressMode, VerbosityLevel
 # Import all parser registration functions
 from .parsers import (
     analyst as analyst_parsers,
+)
+from .parsers import (
+    cleanup_agent as cleanup_agent_parsers,
 )
 from .parsers import (
     architect as architect_parsers,
@@ -307,6 +311,7 @@ def register_all_parsers(parser: argparse.ArgumentParser) -> None:
     ops_parsers.add_ops_parser(subparsers)
     enhancer_parsers.add_enhancer_parser(subparsers)
     evaluator_parsers.add_evaluator_parser(subparsers)
+    cleanup_agent_parsers.add_cleanup_agent_parser(subparsers)
 
     # Register top-level parsers
     top_level_parsers.add_top_level_parsers(subparsers)
@@ -334,6 +339,7 @@ def _get_agent_command_handlers() -> dict[str, Callable[[argparse.Namespace], No
         "ops": ops.handle_ops_command,
         "enhancer": enhancer.handle_enhancer_command,
         "evaluator": evaluator.handle_evaluator_command,
+        "cleanup-agent": cleanup_agent.handle_cleanup_agent_command,
     }
 
 

--- a/tapps_agents/cli/parsers/cleanup_agent.py
+++ b/tapps_agents/cli/parsers/cleanup_agent.py
@@ -1,0 +1,228 @@
+"""
+Cleanup Agent parser definitions
+"""
+import argparse
+
+
+def add_cleanup_agent_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add cleanup-agent parser and subparsers."""
+    cleanup_agent_parser = subparsers.add_parser(
+        "cleanup-agent",
+        help="Project Cleanup Agent commands",
+        description="""Project structure analysis and intelligent cleanup agent.
+
+The Cleanup Agent helps keep projects clean by:
+  - Analyzing project structure for cleanup opportunities
+  - Detecting duplicate files and content
+  - Identifying outdated documentation
+  - Enforcing naming conventions (kebab-case)
+  - Generating cleanup plans with rationale
+  - Executing cleanup operations safely with backups
+
+Use this agent for guided project and docs cleanup after heavy development.""",
+    )
+    cleanup_subparsers = cleanup_agent_parser.add_subparsers(
+        dest="command",
+        help="Cleanup agent subcommand (use 'help' to see all available commands)",
+    )
+
+    # Analyze command
+    analyze_parser = cleanup_subparsers.add_parser(
+        "analyze",
+        aliases=["*analyze"],
+        help="Analyze project structure for cleanup opportunities",
+        description="""Analyze project structure to identify cleanup opportunities.
+
+Scans the specified path and detects:
+  - Duplicate files (by content hash)
+  - Outdated files (not modified in 90+ days)
+  - Naming convention violations
+  - Files with no references
+
+Example:
+  tapps-agents cleanup-agent analyze --path ./docs --pattern "*.md"
+  tapps-agents cleanup-agent analyze --output analysis.json""",
+    )
+    analyze_parser.add_argument(
+        "--path",
+        help="Path to analyze (defaults to ./docs). Can be any directory in the project.",
+    )
+    analyze_parser.add_argument(
+        "--pattern",
+        default="*.md",
+        help="File pattern to match (default: *.md). Supports glob patterns.",
+    )
+    analyze_parser.add_argument(
+        "--output",
+        help="Output file for analysis report (JSON format). If not specified, displays summary.",
+    )
+    analyze_parser.add_argument(
+        "--format",
+        choices=["json", "text", "markdown"],
+        default="json",
+        help="Output format: 'json' for structured data (default), 'text' for human-readable, 'markdown' for markdown",
+    )
+
+    # Plan command
+    plan_parser = cleanup_subparsers.add_parser(
+        "plan",
+        aliases=["*plan"],
+        help="Generate cleanup plan from analysis",
+        description="""Generate a cleanup plan with prioritized actions.
+
+Creates a plan based on analysis that includes:
+  - File categorization (keep, archive, delete, merge, rename)
+  - Priority levels (high, medium, low)
+  - Safety levels (safe, moderate, risky)
+  - Rationale for each action
+  - Estimated space savings
+
+Example:
+  tapps-agents cleanup-agent plan --analysis-file analysis.json
+  tapps-agents cleanup-agent plan --path ./docs --output cleanup-plan.json""",
+    )
+    plan_parser.add_argument(
+        "--analysis-file",
+        help="Path to analysis report JSON. If not provided, runs fresh analysis.",
+    )
+    plan_parser.add_argument(
+        "--path",
+        help="Path to analyze if no analysis file provided (defaults to ./docs).",
+    )
+    plan_parser.add_argument(
+        "--pattern",
+        default="*.md",
+        help="File pattern if running fresh analysis (default: *.md).",
+    )
+    plan_parser.add_argument(
+        "--output",
+        help="Output file for cleanup plan (JSON format).",
+    )
+    plan_parser.add_argument(
+        "--format",
+        choices=["json", "text", "markdown"],
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    # Execute command
+    execute_parser = cleanup_subparsers.add_parser(
+        "execute",
+        aliases=["*execute"],
+        help="Execute cleanup plan (dry-run by default)",
+        description="""Execute cleanup operations from a plan.
+
+Performs cleanup actions with safety measures:
+  - Dry-run mode by default (preview changes)
+  - Optional backup creation before execution
+  - Reference updating for renamed/moved files
+  - Transaction logging for rollback capability
+
+Example:
+  tapps-agents cleanup-agent execute --plan-file cleanup-plan.json --dry-run
+  tapps-agents cleanup-agent execute --plan-file cleanup-plan.json --no-dry-run --backup""",
+    )
+    execute_parser.add_argument(
+        "--plan-file",
+        help="Path to cleanup plan JSON. If not provided, generates plan from analysis.",
+    )
+    execute_parser.add_argument(
+        "--path",
+        help="Path to analyze if no plan file provided (defaults to ./docs).",
+    )
+    execute_parser.add_argument(
+        "--pattern",
+        default="*.md",
+        help="File pattern if running fresh (default: *.md).",
+    )
+    execute_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Preview changes without executing (default: True).",
+    )
+    execute_parser.add_argument(
+        "--no-dry-run",
+        action="store_true",
+        help="Execute changes for real (disables dry-run).",
+    )
+    execute_parser.add_argument(
+        "--backup",
+        action="store_true",
+        default=True,
+        help="Create backup before execution (default: True).",
+    )
+    execute_parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip backup creation (not recommended).",
+    )
+    execute_parser.add_argument(
+        "--format",
+        choices=["json", "text", "markdown"],
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    # Run command (full workflow)
+    run_parser = cleanup_subparsers.add_parser(
+        "run",
+        aliases=["*run"],
+        help="Run full cleanup workflow (analyze, plan, execute)",
+        description="""Run the complete cleanup workflow in one command.
+
+Executes all steps:
+  1. Analyze project structure
+  2. Generate cleanup plan
+  3. Execute cleanup operations
+
+By default runs in dry-run mode with backups enabled.
+
+Example:
+  tapps-agents cleanup-agent run --path ./docs --dry-run
+  tapps-agents cleanup-agent run --path ./docs --no-dry-run --backup""",
+    )
+    run_parser.add_argument(
+        "--path",
+        help="Path to analyze (defaults to ./docs).",
+    )
+    run_parser.add_argument(
+        "--pattern",
+        default="*.md",
+        help="File pattern to match (default: *.md).",
+    )
+    run_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Preview changes without executing (default: True).",
+    )
+    run_parser.add_argument(
+        "--no-dry-run",
+        action="store_true",
+        help="Execute changes for real (disables dry-run).",
+    )
+    run_parser.add_argument(
+        "--backup",
+        action="store_true",
+        default=True,
+        help="Create backup before execution (default: True).",
+    )
+    run_parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip backup creation (not recommended).",
+    )
+    run_parser.add_argument(
+        "--format",
+        choices=["json", "text", "markdown"],
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    # Help command
+    cleanup_subparsers.add_parser(
+        "help",
+        aliases=["*help"],
+        help="Show cleanup agent commands",
+    )

--- a/tapps_agents/core/config.py
+++ b/tapps_agents/core/config.py
@@ -576,6 +576,43 @@ class EvaluatorAgentConfig(BaseModel):
     )
 
 
+class CleanupAgentConfig(BaseModel):
+    """Configuration specific to Cleanup Agent"""
+
+    dry_run_default: bool = Field(
+        default=True,
+        description="Run in dry-run mode by default (preview changes without executing)"
+    )
+    backup_enabled: bool = Field(
+        default=True,
+        description="Create backups before destructive operations"
+    )
+    interactive_mode: bool = Field(
+        default=True,
+        description="Prompt for confirmation on risky operations"
+    )
+    default_pattern: str = Field(
+        default="*.md",
+        description="Default file pattern for analysis"
+    )
+    age_threshold_days: int = Field(
+        default=90,
+        ge=1,
+        le=365,
+        description="Days threshold for detecting outdated files"
+    )
+    similarity_threshold: float = Field(
+        default=0.8,
+        ge=0.0,
+        le=1.0,
+        description="Content similarity threshold for detecting near-duplicates"
+    )
+    backup_dir: str = Field(
+        default=".cleanup-backups",
+        description="Directory for cleanup backups"
+    )
+
+
 class ExpertConfig(BaseModel):
     """Configuration for expert consultation system"""
 
@@ -696,6 +733,7 @@ class AgentsConfig(BaseModel):
         default_factory=OrchestratorAgentConfig
     )
     evaluator: EvaluatorAgentConfig = Field(default_factory=EvaluatorAgentConfig)
+    cleanup_agent: CleanupAgentConfig = Field(default_factory=CleanupAgentConfig)
 
 
 class CheckpointFrequencyConfig(BaseModel):

--- a/tests/unit/agents/test_cleanup_agent.py
+++ b/tests/unit/agents/test_cleanup_agent.py
@@ -1,0 +1,225 @@
+"""
+Unit tests for Cleanup Agent.
+
+Tests agent initialization, command handling, analysis, planning, and execution.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tapps_agents.agents.cleanup.agent import CleanupAgent
+
+pytestmark = pytest.mark.unit
+
+
+class TestCleanupAgentInitialization:
+    """Tests for CleanupAgent initialization."""
+
+    @patch("tapps_agents.agents.cleanup.agent.load_config")
+    def test_cleanup_agent_init(self, mock_load_config):
+        """Test CleanupAgent initialization."""
+        mock_config = MagicMock()
+        mock_config.agents = MagicMock()
+        mock_config.agents.cleanup_agent = MagicMock()
+        mock_config.agents.cleanup_agent.dry_run_default = True
+        mock_config.agents.cleanup_agent.backup_enabled = True
+        mock_config.agents.cleanup_agent.interactive_mode = True
+        mock_load_config.return_value = mock_config
+
+        agent = CleanupAgent()
+        assert agent.agent_id == "cleanup-agent"
+        assert agent.agent_name == "Cleanup Agent"
+        assert agent.config is not None
+        assert agent.dry_run_default is True
+        assert agent.backup_enabled is True
+
+    @pytest.mark.asyncio
+    async def test_cleanup_agent_activate(self):
+        """Test CleanupAgent activation."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            agent = CleanupAgent()
+            await agent.activate(temp_path)
+
+            assert agent.config is not None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_agent_get_commands(self):
+        """Test CleanupAgent command list."""
+        agent = CleanupAgent()
+        commands = agent.get_commands()
+
+        assert isinstance(commands, list)
+        assert len(commands) > 0
+        command_names = [cmd["command"] for cmd in commands]
+        assert "*analyze" in command_names
+        assert "*plan" in command_names
+        assert "*execute" in command_names
+        assert "*run" in command_names
+
+
+class TestCleanupAgentAnalyzeCommand:
+    """Tests for analyze command."""
+
+    @pytest.mark.asyncio
+    async def test_analyze_command_path_not_exists(self):
+        """Test analyze command with non-existent path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            agent = CleanupAgent()
+            await agent.activate(temp_path)
+
+            result = await agent.run(
+                "analyze", path=str(temp_path / "nonexistent")
+            )
+
+            assert result["success"] is False
+            assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_analyze_command_success(self):
+        """Test analyze command with valid path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            # Create some test files
+            docs_dir = temp_path / "docs"
+            docs_dir.mkdir()
+            (docs_dir / "test1.md").write_text("# Test 1\nContent")
+            (docs_dir / "test2.md").write_text("# Test 2\nContent")
+
+            agent = CleanupAgent()
+            await agent.activate(temp_path)
+
+            result = await agent.run("analyze", path=str(docs_dir))
+
+            assert result["type"] == "analyze"
+            assert result["success"] is True
+            assert "report" in result
+            assert result["report"]["total_files"] == 2
+
+
+class TestCleanupAgentPlanCommand:
+    """Tests for plan command."""
+
+    @pytest.mark.asyncio
+    async def test_plan_command_success(self):
+        """Test plan command with valid path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            # Create some test files
+            docs_dir = temp_path / "docs"
+            docs_dir.mkdir()
+            (docs_dir / "test1.md").write_text("# Test 1\nContent")
+            (docs_dir / "test1_copy.md").write_text("# Test 1\nContent")  # Duplicate
+
+            agent = CleanupAgent()
+            await agent.activate(temp_path)
+
+            result = await agent.run("plan", path=str(docs_dir))
+
+            assert result["type"] == "plan"
+            assert result["success"] is True
+            assert "plan" in result
+            assert "total_actions" in result["plan"]
+
+
+class TestCleanupAgentExecuteCommand:
+    """Tests for execute command."""
+
+    @pytest.mark.asyncio
+    async def test_execute_command_dry_run(self):
+        """Test execute command in dry-run mode."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            # Create some test files
+            docs_dir = temp_path / "docs"
+            docs_dir.mkdir()
+            (docs_dir / "test1.md").write_text("# Test 1\nContent")
+
+            agent = CleanupAgent()
+            await agent.activate(temp_path)
+
+            result = await agent.run(
+                "execute", path=str(docs_dir), dry_run=True, backup=False
+            )
+
+            assert result["type"] == "execute"
+            assert result["success"] is True
+            assert result["dry_run"] is True
+
+
+class TestCleanupAgentRunCommand:
+    """Tests for run command (full workflow)."""
+
+    @pytest.mark.asyncio
+    async def test_run_command_path_not_exists(self):
+        """Test run command with non-existent path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            agent = CleanupAgent()
+            await agent.activate(temp_path)
+
+            result = await agent.run(
+                "run", path=str(temp_path / "nonexistent")
+            )
+
+            assert result["success"] is False
+            assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_run_command_success(self):
+        """Test run command with valid path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            # Create some test files
+            docs_dir = temp_path / "docs"
+            docs_dir.mkdir()
+            (docs_dir / "test1.md").write_text("# Test 1\nContent")
+            (docs_dir / "test2.md").write_text("# Test 2\nDifferent content")
+
+            agent = CleanupAgent()
+            await agent.activate(temp_path)
+
+            result = await agent.run(
+                "run", path=str(docs_dir), dry_run=True, backup=False
+            )
+
+            assert result["type"] == "run"
+            assert result["success"] is True
+            assert result["dry_run"] is True
+            assert "analysis" in result
+            assert "plan" in result
+            assert "execution" in result
+
+
+class TestCleanupAgentHelp:
+    """Tests for help command."""
+
+    @pytest.mark.asyncio
+    async def test_help_command(self):
+        """Test help command."""
+        agent = CleanupAgent()
+        result = await agent.run("help")
+
+        assert result["type"] == "help"
+        assert "content" in result
+        assert "*analyze" in result["content"]
+        assert "*plan" in result["content"]
+        assert "*execute" in result["content"]
+        assert "*run" in result["content"]
+
+
+class TestCleanupAgentUnknownCommand:
+    """Tests for unknown command handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_command(self):
+        """Test unknown command returns error."""
+        agent = CleanupAgent()
+        result = await agent.run("unknown_command")
+
+        assert "error" in result
+        assert "unknown command" in result["error"].lower()


### PR DESCRIPTION
Add a new Cleanup Agent that provides guided project and docs cleanup:

- CleanupAgent class extending BaseAgent with analyze, plan, execute, run commands
- CLI parser and command handler for `tapps-agents cleanup-agent` subcommand
- CleanupAgentConfig with dry_run_default, backup_enabled, similarity_threshold settings
- Unit tests for all agent commands

The agent wraps the existing project_cleanup_agent utility to provide:
- Analysis of project structure (duplicates, outdated files, naming issues)
- Cleanup plan generation with prioritized actions
- Safe execution with dry-run mode and backups by default
- Full workflow automation with `run` command

Implements feature request from docs/feedback/github-issue-project-cleanup-agent.md

https://claude.ai/code/session_01BjEF6dRarRYzq2a5mvLjPx