### PR TITLE
fix(orchestrator): add missing empty list guard in fix_orchestrator

### DIFF
--- a/tapps_agents/simple_mode/orchestrators/fix_orchestrator.py
+++ b/tapps_agents/simple_mode/orchestrators/fix_orchestrator.py
@@ -564,7 +564,7 @@ class FixOrchestrator(SimpleModeOrchestrator):
             try:
                 # Generate commit message if not provided
                 if not commit_message:
-                    final_scores = review_results[-1]["result"].get("scores", {})
+                    final_scores = review_results[-1]["result"].get("scores", {}) if review_results else {}
                     overall_score = final_scores.get("overall_score", 0)
                     commit_message = (
                         f"Fix: {bug_description}\n\n"


### PR DESCRIPTION
Add safety check for empty review_results list before accessing
review_results[-1] at line 567. This prevents an IndexError when
no review results are available during auto-commit message generation.

The fix aligns this code path with the other three occurrences in the
same file (lines 478, 686, 720) which already have proper guards.

https://claude.ai/code/session_013DMGgSDbypEMdbdc6skWYS